### PR TITLE
Add isomorphic window library in order to support SSR.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "dependencies": {
+    "ssr-window": "^4.0.2"
   }
 }

--- a/src/ssrWindow.ts
+++ b/src/ssrWindow.ts
@@ -1,0 +1,6 @@
+import { ssrWindow, extend } from 'ssr-window';
+
+extend(ssrWindow, {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    postMessage: (message: any, targetOrigin: any, transfer?: any) => {}
+});

--- a/src/useEventBus.tsx
+++ b/src/useEventBus.tsx
@@ -1,3 +1,4 @@
+import { getWindow } from 'ssr-window';
 import {
     PublishOptions,
     SubscribeOptions,
@@ -7,11 +8,11 @@ import {
 
 const defaultPublishOptions: PublishOptions = {
     targetOrigin: '*',
-    targetWindow: window
+    targetWindow: getWindow()
 };
 
 const defaultSubscribeOptions: SubscribeOptions = {
-    targetWindow: window
+    targetWindow: getWindow()
 };
 
 const useEventBus = <MessagesMap extends Record<string, any>>() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,6 +4115,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+ssr-window@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-4.0.2.tgz#dc6b3ee37be86ac0e3ddc60030f7b3bc9b8553be"
+  integrity sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"


### PR DESCRIPTION
Using event-bus with in server-side rendered code causes the problems because of the lack of a Window object. In order to fix this, we are now using an isomorphic ssr window library to allow code to be executed properly on the server-side.